### PR TITLE
clean up team db after test session run

### DIFF
--- a/code/TestSessionEnvironment.php
+++ b/code/TestSessionEnvironment.php
@@ -362,6 +362,15 @@ class TestSessionEnvironment extends Object
         $this->extend('onBeforeEndTestSession');
 
         if (SapphireTest::using_temp_db()) {
+            $state = $this->getState();
+            $dbConn = DB::getConn();
+            $dbExists = $dbConn->databaseExists($state->database);
+            if($dbExists) {
+                // Clean up temp database
+                $dbConn->dropDatabase();
+                file_put_contents('php://stdout', "Deleted temp database: $state->database" . PHP_EOL);
+            }
+            // End test session mode
             $this->resetDatabaseName();
 
             SapphireTest::set_is_running_test(false);


### PR DESCRIPTION
Added dropDatabase() to clean up temp database at the end of Behat test session.