### PR TITLE
FIX Remove call to non-existent constructExtensions method

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -80,7 +80,6 @@ class TestSessionEnvironment
 
     public function __construct($id = null)
     {
-        $this->constructExtensions();
         if ($id) {
             $this->id = $id;
         }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/runs/8126807181?check_suite_focus=true
> Uncaught BadMethodCallException: Object->__call(): the method 'constructExtensions' does not exist on 'SilverStripe\TestSession\TestSessionEnvironment'

## Parent issues
- https://github.com/silverstripe/silverstripe-framework/issues/10389
- https://github.com/silverstripeltd/product-issues/issues/591