### PR TITLE
FIX Handle invalid json data

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -529,7 +529,10 @@ class TestSessionEnvironment
     public function getState()
     {
         $path = Director::getAbsFile($this->getFilePath());
-        return (file_exists($path ?? '')) ? json_decode(file_get_contents($path)) : new stdClass;
+        if (file_exists($path ?? '')) {
+            return json_decode(file_get_contents($path)) ?: new stdClass;
+        }
+        return new stdClass;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/665

Handle a non-fatal warning during behat detected in an error.log during failed run in https://github.com/silverstripe/silverstripe-installer/actions/runs/3988224788/jobs/6845034234#step:32:1097

`[Mon Jan 23 16:12:05.375547 2023] [php7:warn] [pid 70760] [client ::1:58058] PHP Warning:  Creating default object from empty value in /home/runner/work/silverstripe-installer/silverstripe-installer/vendor/silverstripe/testsession/src/TestSessionHTTPMiddleware.php on line 95, referer: http://localhost/admin/assets/show/2/edit/4`

